### PR TITLE
feature: set api path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mediawiki-matrix-bot
 
 
-A Bot which publishes mediawiki Recent Changes from the [`api.php` endpoint](https://nixos.wiki/api.php?action=help&modules=query%2Brecentchanges) to a matrix room.
+A Bot which publishes mediawiki Recent Changes from the [`api.php` endpoint](https://wiki.nixos.org/w/api.php?action=help&modules=query%2Brecentchanges) to a matrix room.
 
 ## Configuration with `config.json`
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
 # mediawiki-matrix-bot
 
 
-A Bot which publishes mediawiki Recent Changes from the [`/api.php` endpoint](https://nixos.wiki/api.php?action=help&modules=query%2Brecentchanges) to a matrix room.
+A Bot which publishes mediawiki Recent Changes from the [`api.php` endpoint](https://nixos.wiki/api.php?action=help&modules=query%2Brecentchanges) to a matrix room.
+
+## Configuration with `config.json`
+
+### `baseurl`
+
+The baseurl is the the domain and path of the mediawiki server, e.g.
+`https://wiki.nixos.org`
+
+### `api_path`
+The default path to the api is `{baseurl}/api.php`. If the api endpoint is not
+at the default location like in wiki.nixos.org it can be set to `/w/api.php` to
+query a different endpoint.
 
 
 ## Development

--- a/config.json.example
+++ b/config.json.example
@@ -4,5 +4,6 @@
     "password": "my-voice-is-my-password",
     "room": "!roomid:servername.net",
     "baseurl": "https://mediawiki.example",
+    "api_path": "/api.php",
     "timeout": 60
 }

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 pkgs.python3Packages.buildPythonApplication {
   pname = "mediawiki-matrix-bot";
-  version = "1.0.0";
+  version = "1.1.0";
   src = ./.;
   propagatedBuildInputs = with pkgs.python3Packages; [
     feedparser matrix-nio docopt aiohttp aiofiles

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711715736,
+        "narHash": "sha256-9slQ609YqT9bT/MNX9+5k5jltL9zgpn36DpFB7TkttM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "807c549feabce7eddbf259dbdcec9e0600a0660d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,15 @@
+{
+  description = "mediawiki_matrix_bot flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }: {
+
+    packages.x86_64-linux.mediawiki_matrix_bot = nixpkgs.legacyPackages.x86_64-linux.callPackage ./default.nix {};
+
+    packages.x86_64-linux.default = self.packages.x86_64-linux.mediawiki_matrix_bot;
+
+  };
+}

--- a/mediawiki_matrix_bot/__init__.py
+++ b/mediawiki_matrix_bot/__init__.py
@@ -182,13 +182,13 @@ async def fetch_changes(baseurl: str, api_path: str = "/api.php") -> Any:
 
 
 async def check_recent_changes(
-        client: AsyncClient, room: str, baseurl: str, api_path:str, timeout: int
+        client: AsyncClient, room: str, baseurl: str, api_path: str, timeout: int
 ) -> None:
     # initial fetch of the last recent change, there is no state handling here,
     # we do not re-notify changes in case the bot is offline
     log.info("Fetching last changes initially")
     with die_on_exception("Something went wrong when fetching the the first change from the wiki"):
-        resp = await fetch_changes(baseurl)
+        resp = await fetch_changes(baseurl, api_path)
     last_rc = resp["query"]["recentchanges"][0]["rcid"]
 
     log.info(f"The last rc is {last_rc}")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="mediawiki-matrix-bot",
-    version="1.0.0",
+    version="1.1.0",
     description="Matrix bot that publishes mediawiki recent changes",
     author="makefu",
     author_email="github@syntax-fehler.de",


### PR DESCRIPTION
with the new wiki the `api.php` is not stored in root anymore but in `/w/api.php`
The PR adds a configuration option to change the api path as well as documentation to account for it.